### PR TITLE
Configured Logstash and Kibana

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -79,17 +79,42 @@ services:
 
 
   elasticsearch:
-    image: elasticsearch:8.2.2
+    image: elasticsearch:8.7.1
+    container_name: elasticsearch
     ports:
       - "9200:9200"
     volumes:
       - es-data:/usr/share/elasticsearch/data
     environment:
-      - http.host=0.0.0.0
-      - transport.host=127.0.0.1
       - discovery.type=single-node
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
       - xpack.security.enabled=false
+
+  kibana:
+    image: kibana:8.7.1
+    container_name: kibana
+    restart: always
+    ports:
+      - "5601:5601"
+    environment:
+      - ELASTICSEARCH_URL=http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
+
+  logstash:
+    image: logstash:8.7.1
+    container_name: logstash
+    restart: always
+    volumes:
+      - ../logstash/logstash.conf:/usr/share/logstash/pipeline/logstash.conf
+      - ../logs/:/usr/share/logstash/logs
+      - logstash-data:/usr/share/logstash/pipeline/
+    depends_on:
+      - elasticsearch
+    ports:
+      - "9600:9600"
+    environment:
+      - LS_JAVA_OPTS=-Xmx256m -Xms256m
 
 volumes:
   postgres-data:
@@ -97,5 +122,7 @@ volumes:
   es-data:
     driver: local
   mongodb-data:
+    driver: local
+  logstash-data:
     driver: local
 

--- a/logstash/logstash.conf
+++ b/logstash/logstash.conf
@@ -1,0 +1,11 @@
+input {
+  file {
+    path => "/usr/share/logstash/logs/*.log"
+    start_position => "beginning"
+  }
+}
+output {
+  elasticsearch {
+    hosts => ["elasticsearch:9200"]
+  }
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds Logstash to the Docker Compose setup and configures it to read logs from a specific directory and send them to Elasticsearch. It also updates the Elasticsearch and Kibana images to version 8.7.1.

### Detailed summary
- Added Logstash to Docker Compose setup
- Configured Logstash to read logs from `/usr/share/logstash/logs/*.log` and send them to Elasticsearch
- Updated Elasticsearch and Kibana images to version 8.7.1
- Added `logstash-data` volume for Logstash pipeline data

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->